### PR TITLE
Refactor Gmail/Gemini email scan into auditable staged pipeline

### DIFF
--- a/back/src/Tracker.js
+++ b/back/src/Tracker.js
@@ -137,22 +137,21 @@ export default function Tracker(app, db) {
    * @param {boolean} allPages: optional, first page by default (gmail API)
    */
   app.post("/api/applications/scan", async (req, res) => {
-
-    const { access_token } = req.body;
+    const { access_token, lastHistoryId, pubSubPayload } = req.body;
     const limit = parseInt(req.query.limit) || 100;
 
     try {
-      let emailParser = new EmailParser(access_token, limit);
-      await emailParser.genericApplicationParser();
+      const emailParser = new EmailParser(access_token, limit);
+      const result = await emailParser.runPipeline({
+        lastHistoryId: lastHistoryId || null,
+        pubSubPayload: pubSubPayload || null,
+      });
+      return res.json(result);
     } catch (e) {
       return res
-        .status(e.status)
+        .status(e.status || 500)
         .json({ status: false, message: `Error fetching emails: ${e}` });
     }
-    let query = await ApplicationModel.find({}, null, {
-      sort: { updatedDate: -1 },
-    });
-    return res.json(query);
   });
 
   app.post("/api/application", async (req, res) => {

--- a/back/src/services/GeminiApi.js
+++ b/back/src/services/GeminiApi.js
@@ -1,169 +1,80 @@
 import { VertexAI } from "@google-cloud/vertexai";
-import { delay, validateUrl } from "../utils";
 
-const tools = [
-  {
-    function_declarations: [
-      {
-        name: "extract_job_details",
-        description: `Extract job details from the email and set status of the job application according to the email`,
-        parameters: {
-          type: "object",
-          required: ["company"],
-          properties: {
-            status: {
-              type: "string",
-              enum: [
-                "Applied",
-                "In progress",
-                "Rejected",
-                "Not an application",
-              ],
-              description: `Categorize email as "Applied" by default, "Rejected" it the candidate has been rejected, "In progress" if there is an interview scheduled or an assignment to be completed`,
-            },
-            job_title: {
-              type: "string",
-              description: `The job title.`,
-            },
-            company: {
-              type: "string",
-              description: `The company name.`,
-            },
-            location: {
-              type: "string",
-              description: `The city where the job is located.`,
-            },
-            application_link: {
-              type: "string",
-              description: `The application link.`,
-            },
-            job_requirements: {
-              type: "string",
-              description: `Optional. The job requirements if you can find it, otherwise leave it empty.`,
-            },
-            city: {
-              type: "string",
-              description: `Optional. The city in which the candidate has to work`,
-            },
-            work_mode: {
-              type: "string",
-              description: `Is it hybrid, remote or on-site? Optional, leave empty if there no information.`,
-            },
-            contract_type: {
-              type: "string",
-              description: `Optional. Is it a full-time, part-time or internship? Is it a permanent or temporary contract?`,
-            },
-            salary: {
-              type: "string",
-              description: `Optional. The salary.`,
-            },
-          },
-        },
-      },
-    ],
+export const CLASSIFICATION_SCHEMA = {
+  type: "object",
+  required: ["is_job_related", "confidence", "reason"],
+  properties: {
+    is_job_related: { type: "boolean" },
+    confidence: { type: "number" },
+    reason: { type: "string" },
   },
-];
+};
 
-/**
- * Class to interact with the Gemini API
- * 
- * Docs: https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/gemini
- * GCloud Project Console: https://console.cloud.google.com/apis/credentials?project=jobhub-415000
- */
+export const EXTRACTION_SCHEMA = {
+  type: "object",
+  required: ["company", "confidence"],
+  properties: {
+    status: { type: "string" },
+    job_title: { type: "string" },
+    company: { type: "string" },
+    location: { type: "string" },
+    application_link: { type: "string" },
+    job_requirements: { type: "string" },
+    confidence: { type: "number" },
+    thread_id: { type: "string" },
+  },
+};
+
 export default class GeminiApi {
-
-  static max_output_tokens = 256;
-  static regions = ["us-central1", "europe-west1", "europe-west2", "europe-west3", "europe-west4", "europe-west9", "northamerica-northeast1", "asia-northeast1", "asia-northeast3", "asia-southeast1"]
+  static max_output_tokens = 512;
+  static regions = ["us-central1", "europe-west1", "europe-west2", "asia-northeast1"];
 
   constructor() {
     this.currentRegionIndex = 0;
   }
 
-  /**
-   * Rotate regions so that we don't hit the rate limit
-   * most of servers have max request per minute of only 60
-   * 
-   * https://cloud.google.com/vertex-ai/generative-ai/docs/quotas
-   */
   setRegionIndex() {
-    if (this.currentRegionIndex < this.constructor.regions.length - 1) {
-      this.currentRegionIndex = this.currentRegionIndex + 1;
-    } else {
-      this.currentRegionIndex = 0;
-    }
+    this.currentRegionIndex = (this.currentRegionIndex + 1) % this.constructor.regions.length;
   }
 
-  setupAi() {
+  setupModel() {
     this.setRegionIndex();
     const vertexAi = new VertexAI({
       project: process.env.PROJECT_ID,
       location: this.constructor.regions[this.currentRegionIndex],
     });
-    const model = vertexAi.getGenerativeModel({
-      model: "gemini-pro",
+
+    return vertexAi.getGenerativeModel({
+      model: "gemini-2.0-flash-001",
       generation_config: {
         max_output_tokens: this.constructor.max_output_tokens,
+        temperature: 0,
+      },
+    });
+  }
+
+  async requestJson(prompt, schema) {
+    const model = this.setupModel();
+    const result = await model.generateContent({
+      contents: [{ role: "user", parts: [{ text: prompt }] }],
+      generationConfig: {
+        responseMimeType: "application/json",
+        responseSchema: schema,
       },
     });
 
-    const chat = model.startChat({
-      tools: tools,
-    });
-    return chat;
+    const text = result?.response?.candidates?.[0]?.content?.parts?.[0]?.text || "{}";
+    console.log("gemini_raw_output", text);
+    return JSON.parse(text);
   }
 
-  async sendMessage(input) {
-    const chat = this.setupAi();
-    return await chat.sendMessageStream(input);
+  async classifyEmail({ subject, snippet, text }) {
+    const prompt = `Classify whether this email is related to a job application pipeline. Return strict JSON.\nSubject: ${subject || ""}\nSnippet: ${snippet || ""}\nBody: ${text || ""}`;
+    return this.requestJson(prompt, CLASSIFICATION_SCHEMA);
   }
 
-  /**
-   * Extract job details from application link
-   * 
-   * @param {string} url - The URL of the email
-   * @returns {HTML} - The job details
-   */
-  async getApplicationDetails(url) {
-    const page = await fetch(url);
-    const text = await page.text();
-    const prompt = `Extract job details: ${text}`;
-    const result = await this.sendMessage(prompt);
-    return result;
-  }
-
-  async classifyEmails(part) {
-
-    let data = null;
-    const chatInput1 = `Is this email is related to a job application? If it is, extract job details: ${part.text}`;
-    const result = await this.sendMessage(chatInput1);
-    // sometimes response takes time to process
-    for await (const chunk of result.stream) {
-      if (chunk.candidates[0].content && chunk.candidates[0].content?.parts && chunk.candidates[0].content.parts[0].functionCall) {
-        const { functionCall } = chunk.candidates[0].content.parts[0];
-        if (functionCall && functionCall.args && functionCall.args.status && functionCall.args.status.toLowerCase() !== "not an application" && functionCall.args.company && functionCall.args.company !== "None") {
-          data = functionCall.args;
-          console.log("region: ", this.constructor.regions[this.currentRegionIndex]);
-          if (validateUrl(data.application_link)) {
-            // Try to change server to avoid 500 errors
-            delay(5000);
-            const results2 = await this.getApplicationDetails(data.application_link);
-            for await (const chunk2 of results2.stream) {
-              if (chunk2.candidates[0].content.parts) {
-                const functionCall2 = chunk2.candidates[0].content.parts[0].functionCall;
-                if (functionCall2 && functionCall2.args) {
-                  data = {...data, ...functionCall2.args};
-                  if (!data.status && functionCall.args.status) {
-                    data.status = functionCall.args.status;
-                  }
-                }
-                break;
-              }
-            }
-          }
-        }
-      }
-      continue;
-    }
-    return data;
+  async extractJobData({ subject, snippet, text }) {
+    const prompt = `Extract job-application details from this email. Return strict JSON.\nSubject: ${subject || ""}\nSnippet: ${snippet || ""}\nBody: ${text || ""}`;
+    return this.requestJson(prompt, EXTRACTION_SCHEMA);
   }
 }

--- a/back/src/services/GmailApi.js
+++ b/back/src/services/GmailApi.js
@@ -6,14 +6,76 @@ export default class GmailApi {
     this.limit = limit;
   }
 
+  getAuthHeaders(extra = {}) {
+    return {
+      Authorization: `Bearer ${this.access_token}`,
+      ...extra,
+    };
+  }
+
+  async startWatch(topicName, labelIds = ["INBOX"]) {
+    const response = await fetch("https://gmail.googleapis.com/gmail/v1/users/me/watch", {
+      method: "POST",
+      headers: this.getAuthHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify({ topicName, labelIds }),
+    });
+
+    return handleResponse(response);
+  }
+
+  async fetchHistory(startHistoryId, pageToken = null, history = []) {
+    let url = `https://gmail.googleapis.com/gmail/v1/users/me/history?startHistoryId=${startHistoryId}&maxResults=${this.limit}`;
+
+    if (pageToken) {
+      url += `&pageToken=${pageToken}`;
+    }
+
+    const response = await fetch(url, {
+      headers: this.getAuthHeaders(),
+    });
+
+    const data = await handleResponse(response);
+    const currentHistory = data.history || [];
+    const all = history.concat(currentHistory);
+
+    if (data.nextPageToken) {
+      return this.fetchHistory(startHistoryId, data.nextPageToken, all);
+    }
+
+    return {
+      history: all,
+      historyId: data.historyId,
+    };
+  }
+
+  decodePubSubMessage(pubSubPayload) {
+    const data = pubSubPayload?.message?.data;
+    if (!data) return null;
+
+    try {
+      const decoded = Buffer.from(data, "base64").toString("utf-8");
+      return JSON.parse(decoded);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  extractMessageIdsFromHistory(history = []) {
+    const ids = new Set();
+
+    history.forEach((entry) => {
+      (entry.messagesAdded || []).forEach((added) => {
+        if (added?.message?.id) ids.add(added.message.id);
+      });
+    });
+
+    return Array.from(ids);
+  }
+
   async fetchIndividualEmail(messageId) {
     const response = await fetch(
       `https://www.googleapis.com/gmail/v1/users/me/messages/${messageId}`,
-      {
-        headers: {
-          Authorization: `Bearer ${this.access_token}`,
-        },
-      }
+      { headers: this.getAuthHeaders() }
     );
     const data = await handleResponse(response);
     return data;
@@ -32,9 +94,7 @@ export default class GmailApi {
     }
 
     const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${this.access_token}`,
-      },
+      headers: this.getAuthHeaders(),
     });
 
     const data = await handleResponse(response);

--- a/back/src/services/emailParser.js
+++ b/back/src/services/emailParser.js
@@ -1,171 +1,130 @@
 import mongoose from "mongoose";
 import { ApplicationSchema } from "../Schemas.js";
-import { escapeRegex } from "../utils.js";
 import GeminiApi from "./GeminiApi.js";
 import GmailApi from "./GmailApi.js";
 
 export default class EmailParser {
-  // This keyword should filter most job application emails
-  static keywords = ["Your application"];
-
   constructor(access_token, limit = 300) {
     this.access_token = access_token;
     this.limit = limit;
     this.gmailApi = new GmailApi(access_token, limit);
     this.geminiApi = new GeminiApi();
-    this.ApplicationModel = mongoose.model(
-      "ApplicationModel",
-      ApplicationSchema
-    );
-    this.contentParts = [];
-    this.jobApplicationEmails = [];
+    this.ApplicationModel = mongoose.model("ApplicationModel", ApplicationSchema);
+    this.reviewQueue = [];
   }
 
-  getApplicationByCompany(company) {
-    let regex = escapeRegex(company);
-    return this.ApplicationModel.findOne({
-      company: { $regex: regex, $options: "i" },
-    });
+  computePrefilterScore({ subject = "", snippet = "", body = "" }) {
+    const text = `${subject} ${snippet} ${body}`.toLowerCase();
+    const positiveSignals = ["application", "interview", "recruiter", "candidate", "hiring", "position", "job"];
+    const negativeSignals = ["discount", "sale", "offer", "coupon", "marketing", "unsubscribe", "shop"];
+
+    const positive = positiveSignals.reduce((acc, s) => (text.includes(s) ? acc + 1 : acc), 0);
+    const negative = negativeSignals.reduce((acc, s) => (text.includes(s) ? acc + 1 : acc), 0);
+
+    return { score: positive - negative, positive, negative };
   }
 
-  updateApplicationByCompany(application) {
-    return this.ApplicationModel.updateOne(
-      {
-        company: application.company,
-      },
-      application
-    );
+  async matchApplication(extraction, threadId) {
+    if (threadId) {
+      const byThread = await this.ApplicationModel.findOne({ threadId });
+      if (byThread) return { application: byThread, confidence: 1, strategy: "threadId" };
+    }
+
+    if (extraction.company) {
+      const byCompany = await this.ApplicationModel.findOne({ company: extraction.company });
+      if (byCompany) return { application: byCompany, confidence: 0.95, strategy: "exact company" };
+    }
+
+    if (extraction.job_title) {
+      const byTitle = await this.ApplicationModel.findOne({ role: extraction.job_title });
+      if (byTitle) return { application: byTitle, confidence: 0.92, strategy: "exact title" };
+
+      const fuzzy = await this.ApplicationModel.findOne({ role: { $regex: extraction.job_title.split(" ")[0], $options: "i" } });
+      if (fuzzy) return { application: fuzzy, confidence: 0.9, strategy: "fuzzy title similarity" };
+    }
+
+    return { application: null, confidence: 0, strategy: "none" };
   }
 
-  parseCompanyName(companyName) {
-    const words = companyName.split(" ");
-    const set = new Set(words);
-    // Remove special character
-    const trimmedCompanyName = Array.from(set)
-      .join(" ")
-      .split(" ")
-      .filter((x) => x !== "͏");
-    return trimmedCompanyName.join(" ");
-  }
+  async guardedUpsert({ extraction, date, emailId, threadId, match }) {
+    if (!(extraction.confidence >= 0.85 && match.confidence >= 0.9)) {
+      this.reviewQueue.push({ emailId, extraction, match });
+      return { status: "review" };
+    }
 
-  async saveApplication(emailData, date, emailId) {
-    const applicationDate = new Date(date);
-    const application = {
-      role: emailData?.job_title,
-      company: emailData.company,
-      location: emailData?.location,
-      applicationUrl: emailData.application_link,
-      updatedAt: new Date(date),
-      status: {
-        text: emailData.status,
-      },
-      description: emailData.job_requirements,
-      location: emailData.city,
-      emailId: emailId,
+    const payload = {
+      role: extraction.job_title,
+      company: extraction.company,
+      location: extraction.location,
+      applicationUrl: extraction.application_link,
+      updatedAt: new Date(date || Date.now()),
+      status: { text: extraction.status || "Applied" },
+      description: extraction.job_requirements,
+      emailId,
+      threadId,
     };
-    const applicationByCompany = await this.getApplicationByCompany(
-      application.company
-    );
-    if (applicationByCompany) {
-      // Check which update is newer
-      if (applicationByCompany.updatedAt < applicationDate) {
-        await this.updateApplicationByCompany(application);
-      }
-    } else {
-      let newApplication = new this.ApplicationModel({
-        _id: mongoose.Types.ObjectId(),
-        role: application.role,
-        company: application.company,
-        location: application.location,
-        applicationUrl: application.applicationUrl,
-        date: application.date,
-        status: application.status,
-        createdAt: applicationDate,
-        updatedAt: applicationDate,
-        emailId: application.emailId,
-      });
-      newApplication.save();
+
+    if (match.application) {
+      await this.ApplicationModel.updateOne({ _id: match.application._id }, payload);
+      return { status: "updated" };
     }
+
+    await this.ApplicationModel.create({
+      _id: mongoose.Types.ObjectId(),
+      ...payload,
+      createdAt: new Date(date || Date.now()),
+    });
+    return { status: "created" };
   }
 
-  /**
-   * Exclude from scanning
-   * - Emails that are rejected
-   *
-   * @returns {string} message.id
-   */
-  async exclusions() {
-    const emailIds = await this.ApplicationModel.aggregate([
-      { $unwind: "$status" },
-      { $match: { "status.value": { $nin: [2, 3] }, emailId: { $ne: null } } },
-      { $project: { _id: 0, emailId: 1 } },
-    ]).exec();
+  async parseMessage(messageId) {
+    const email = await this.gmailApi.fetchIndividualEmail(messageId);
+    const headers = email?.payload?.headers || [];
+    const subject = headers.find((h) => h.name.toLowerCase() === "subject")?.value || "";
+    const date = headers.find((h) => h.name.toLowerCase() === "date")?.value;
+    const threadId = email.threadId;
+    const snippet = email.snippet || "";
+    const part = email?.payload?.parts?.[0]?.body?.data;
+    const text = part ? Buffer.from(part, "base64").toString("utf-8") : "";
 
-    return emailIds.flatMap((email) => (email ? email.id : []));
+    const prefilter = this.computePrefilterScore({ subject, snippet, body: text });
+    if (prefilter.score <= 0) {
+      return { messageId, status: "skipped_prefilter", prefilter };
+    }
+
+    const classification = await this.geminiApi.classifyEmail({ subject, snippet, text });
+    if (!classification?.is_job_related || classification.confidence < 0.8) {
+      return { messageId, status: "skipped_classification", classification };
+    }
+
+    const extraction = await this.geminiApi.extractJobData({ subject, snippet, text });
+    const match = await this.matchApplication(extraction, threadId);
+    const writeResult = await this.guardedUpsert({ extraction, date, emailId: messageId, threadId, match });
+
+    return { messageId, status: writeResult.status, classification, extraction, match };
   }
 
-  async genericApplicationParser() {
-    const messages = await this.gmailApi.fetchListEmails();
+  async runPipeline({ lastHistoryId = null, pubSubPayload = null } = {}) {
+    let messageIds = [];
+    let nextHistoryId = lastHistoryId;
 
-    if (messages.length === 0) {
-      throw new Error("No messages found.");
+    const decoded = this.gmailApi.decodePubSubMessage(pubSubPayload);
+    const historyStart = decoded?.historyId || lastHistoryId;
+
+    if (historyStart) {
+      const historyResult = await this.gmailApi.fetchHistory(historyStart);
+      messageIds = this.gmailApi.extractMessageIdsFromHistory(historyResult.history);
+      nextHistoryId = historyResult.historyId || historyStart;
     } else {
-      const excludeMessageIds = await this.exclusions();
-      for (const message of messages) {
-        // Skip if message is in the exclusion list
-        // to prevent re-scanning of emails
-        if (excludeMessageIds.includes(message.id)) {
-          console.log("Excluded message", message.id);
-          continue;
-        }
-
-        const emailContent = await this.gmailApi.fetchIndividualEmail(
-          message.id
-        );
-        const {
-          snippet,
-          payload: { parts, headers },
-        } = emailContent;
-
-        const subject = headers.find(
-          (header) => header.name.toLowerCase() === "from"
-        ).value;
-
-        const date = headers.find(
-          (date) => date.name.toLowerCase() === "date"
-        ).value;
-
-        if (parts && parts[0].body.size > 0) {
-          const part1 = Buffer.from(parts[0].body.data, "base64").toString(
-            "utf-8"
-          );
-          let processedContent = part1.replace(/\\r\\n/, " ");
-          processedContent = processedContent.replace(/'/g, "\\'");
-
-          const checkForLetters = /[a-zA-Z]/g.test(snippet);
-          if (checkForLetters) {
-            try {
-              const extractedApplicationData =
-                await this.geminiApi.classifyEmails({
-                  text: processedContent,
-                  subject: subject,
-                  id: message.id,
-                });
-              if (extractedApplicationData) {
-                await this.saveApplication(
-                  extractedApplicationData,
-                  date,
-                  message.id
-                );
-              }
-            } catch (error) {
-              console.error("Error classifying emails", error, snippet);
-              break;
-            }
-          }
-        }
-      }
-      console.log("Finished processing emails");
+      const messages = await this.gmailApi.fetchListEmails();
+      messageIds = messages.map((m) => m.id);
     }
+
+    const processed = [];
+    for (const messageId of messageIds) {
+      processed.push(await this.parseMessage(messageId));
+    }
+
+    return { processed, lastHistoryId: nextHistoryId, reviewQueue: this.reviewQueue };
   }
 }

--- a/back/src/services/emailParser.js
+++ b/back/src/services/emailParser.js
@@ -1,5 +1,6 @@
 import mongoose from "mongoose";
 import { ApplicationSchema } from "../Schemas.js";
+import { escapeRegex } from "../utils.js";
 import GeminiApi from "./GeminiApi.js";
 import GmailApi from "./GmailApi.js";
 
@@ -39,7 +40,8 @@ export default class EmailParser {
       const byTitle = await this.ApplicationModel.findOne({ role: extraction.job_title });
       if (byTitle) return { application: byTitle, confidence: 0.92, strategy: "exact title" };
 
-      const fuzzy = await this.ApplicationModel.findOne({ role: { $regex: extraction.job_title.split(" ")[0], $options: "i" } });
+      const fuzzyToken = escapeRegex(extraction.job_title.split(" ")[0]);
+      const fuzzy = await this.ApplicationModel.findOne({ role: { $regex: fuzzyToken, $options: "i" } });
       if (fuzzy) return { application: fuzzy, confidence: 0.9, strategy: "fuzzy title similarity" };
     }
 

--- a/back/src/services/emailParser.js
+++ b/back/src/services/emailParser.js
@@ -109,15 +109,16 @@ export default class EmailParser {
     let nextHistoryId = lastHistoryId;
 
     const decoded = this.gmailApi.decodePubSubMessage(pubSubPayload);
-    const historyStart = decoded?.historyId || lastHistoryId;
+    const notificationHistoryId = decoded?.historyId || null;
 
-    if (historyStart) {
-      const historyResult = await this.gmailApi.fetchHistory(historyStart);
+    if (lastHistoryId) {
+      const historyResult = await this.gmailApi.fetchHistory(lastHistoryId);
       messageIds = this.gmailApi.extractMessageIdsFromHistory(historyResult.history);
-      nextHistoryId = historyResult.historyId || historyStart;
+      nextHistoryId = historyResult.historyId || notificationHistoryId || lastHistoryId;
     } else {
       const messages = await this.gmailApi.fetchListEmails();
       messageIds = messages.map((m) => m.id);
+      nextHistoryId = notificationHistoryId || nextHistoryId;
     }
 
     const processed = [];


### PR DESCRIPTION
### Motivation
- Replace the previous ad-hoc streaming/function-call AI flow with a strict, auditable two-stage pipeline to reduce false positives and prevent unsafe AI-driven DB writes. 
- Enable incremental Gmail ingestion using history/watch IDs and Pub/Sub payloads so only mailbox deltas are processed. 
- Enforce deterministic, reviewable behavior by separating classification and extraction with strict JSON schemas and guarded update rules. 

### Description
- Reworked Gmail integration in `back/src/services/GmailApi.js` to centralize auth headers and add incremental-ingestion helpers: `getAuthHeaders`, `startWatch`, `fetchHistory`, `decodePubSubMessage`, and `extractMessageIdsFromHistory`.
- Replaced the Gemini streaming/function-call approach in `back/src/services/GeminiApi.js` with strict JSON requests and deterministic generation: added `CLASSIFICATION_SCHEMA` and `EXTRACTION_SCHEMA`, a `requestJson(...)` helper, region rotation, deterministic `generation_config` (temperature 0), and raw-AI output logging.
- Implemented a staged, guarded pipeline in `back/src/services/emailParser.js` with deterministic pre-filter scoring (positive job vs negative commerce signals), an AI classification gate (`confidence >= 0.8`), AI extraction, deterministic DB matching order (`threadId` → exact company → exact title → fuzzy title similarity), and guarded writes that only upsert when `extraction.confidence >= 0.85` and `match.confidence >= 0.9`, otherwise enqueue for review.
- Updated the API in `back/src/Tracker.js` for `POST /api/applications/scan` to accept optional `lastHistoryId` and `pubSubPayload`, invoke the new pipeline, and return `{ processed, lastHistoryId, reviewQueue }` instead of returning a full DB query.

### Testing
- Attempted automated build with `cd /workspace/jobhub && yarn run build-js` which failed due to no top-level Yarn project in the environment.
- Attempted `cd /workspace/jobhub/back && yarn run build-js` which failed with a Yarn config parsing error in this environment.
- Attempted `cd /workspace/jobhub/back && npm run build-js` which reached the Babel script but failed because the `babel` CLI is not installed in the execution environment (`babel: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa1992af908320998f0d9fddfc7240)